### PR TITLE
More specific error reporting

### DIFF
--- a/src/Dissect/Lexer/AbstractLexer.php
+++ b/src/Dissect/Lexer/AbstractLexer.php
@@ -55,7 +55,6 @@ abstract class AbstractLexer implements Lexer
      */
     public function lex($string)
     {
-        // normalize line endings
         $string = strtr($string, array("\r\n" => "\n", "\r" => "\n"));
 
         $tokens = array();
@@ -78,7 +77,6 @@ abstract class AbstractLexer implements Lexer
 
             $position += $shift;
 
-            // update line + offset
             if ($position > 0) {
                 $this->line = substr_count($originalString, "\n", 0, $position) + 1;
             }
@@ -87,7 +85,10 @@ abstract class AbstractLexer implements Lexer
         }
 
         if ($position !== $originalLength) {
-            throw new RecognitionException($this->line);
+            $lines = explode("\n", $originalString);
+            $errorLine = $lines[$this->line-1];
+            $linePosition = strpos($errorLine, $string);
+            throw new RecognitionException($string, $linePosition, $this->line);
         }
 
         $tokens[] = new CommonToken(Parser::EOF_TOKEN_TYPE, '', $this->line);

--- a/src/Dissect/Lexer/Exception/RecognitionException.php
+++ b/src/Dissect/Lexer/Exception/RecognitionException.php
@@ -39,7 +39,7 @@ class RecognitionException extends RuntimeException
 
     public function getParameter()
     {
-        return $this->parameter();
+        return $this->parameter;
     }
 
     public function getPosition()

--- a/src/Dissect/Lexer/Exception/RecognitionException.php
+++ b/src/Dissect/Lexer/Exception/RecognitionException.php
@@ -13,7 +13,7 @@ class RecognitionException extends RuntimeException
 {
     protected $parameter;
     protected $position;
-    protected $line;
+    protected $sourceLine;
 
     /**
      * Constructor.
@@ -26,7 +26,7 @@ class RecognitionException extends RuntimeException
     {
         $this->parameter = $parameter;
         $this->position = $position;
-        $this->line = $line;
+        $this->sourceLine = $line;
         $message = sprintf(
             'Invalid Parameter "%s" at line %d position %d',
             $parameter,
@@ -47,7 +47,7 @@ class RecognitionException extends RuntimeException
         return $this->position;
     }
 
-    public function getLine()
+    public function getSourceLine()
     {
         return $this->sourceLine;
     }

--- a/src/Dissect/Lexer/Exception/RecognitionException.php
+++ b/src/Dissect/Lexer/Exception/RecognitionException.php
@@ -16,13 +16,20 @@ class RecognitionException extends RuntimeException
     /**
      * Constructor.
      *
-     * @param int $line The line in the source.
+     * @param string $parameter The unrecognised parameter.
+     * @param int position The character position within the current line where $parameter is located
+     * @param int $line The line in the source where $parameter is located.
      */
-    public function __construct($line)
+    public function __construct($parameter, $position, $line)
     {
-        $this->sourceLine = $line;
+        $message = sprintf(
+            'Invalid Parameter "%s" at line %d position %d',
+            $parameter,
+            $line,
+            $position
+        );
 
-        parent::__construct(sprintf("Cannot extract another token at line %d.", $line));
+        parent::__construct($message);
     }
 
     /**

--- a/src/Dissect/Lexer/Exception/RecognitionException.php
+++ b/src/Dissect/Lexer/Exception/RecognitionException.php
@@ -11,17 +11,22 @@ use RuntimeException;
  */
 class RecognitionException extends RuntimeException
 {
-    protected $sourceLine;
+    protected $parameter;
+    protected $position;
+    protected $line;
 
     /**
      * Constructor.
      *
      * @param string $parameter The unrecognised parameter.
-     * @param int position The character position within the current line where $parameter is located
+     * @param int position The character position within the current line where $parameter is located.
      * @param int $line The line in the source where $parameter is located.
      */
     public function __construct($parameter, $position, $line)
     {
+        $this->parameter = $parameter;
+        $this->position = $position;
+        $this->line = $line;
         $message = sprintf(
             'Invalid Parameter "%s" at line %d position %d',
             $parameter,
@@ -32,12 +37,17 @@ class RecognitionException extends RuntimeException
         parent::__construct($message);
     }
 
-    /**
-     * Returns the source line number where the exception occured.
-     *
-     * @return int The source line number.
-     */
-    public function getSourceLine()
+    public function getParameter()
+    {
+        return $this->parameter();
+    }
+
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    public function getLine()
     {
         return $this->sourceLine;
     }

--- a/tests/Dissect/Lexer/AbstractLexerTest.php
+++ b/tests/Dissect/Lexer/AbstractLexerTest.php
@@ -59,7 +59,7 @@ class AbstractLexerTest extends PHPUnit_Framework_TestCase
             $stream = $this->lexer->lex("abcd");
             $this->fail('Expected a RecognitionException.');
         } catch (RecognitionException $e) {
-            $this->assertEquals(1, $e->getLine());
+            $this->assertEquals(1, $e->getSourceLine());
             $this->assertEquals(0, $e->getPosition());
             $this->assertEquals('abcd', $e->getParameter());
         }

--- a/tests/Dissect/Lexer/AbstractLexerTest.php
+++ b/tests/Dissect/Lexer/AbstractLexerTest.php
@@ -61,7 +61,7 @@ class AbstractLexerTest extends PHPUnit_Framework_TestCase
         } catch (RecognitionException $e) {
             $this->assertEquals(1, $e->getSourceLine());
             $this->assertEquals(3, $e->getPosition());
-            $this->assertEquals('abcd', $e->getParameter());
+            $this->assertEquals('d', $e->getParameter());
         }
     }
 

--- a/tests/Dissect/Lexer/AbstractLexerTest.php
+++ b/tests/Dissect/Lexer/AbstractLexerTest.php
@@ -59,7 +59,9 @@ class AbstractLexerTest extends PHPUnit_Framework_TestCase
             $stream = $this->lexer->lex("abcd");
             $this->fail('Expected a RecognitionException.');
         } catch (RecognitionException $e) {
-            $this->assertEquals(1, $e->getSourceLine());
+            $this->assertEquals(1, $e->getLine());
+            $this->assertEquals(0, $e->getPosition());
+            $this->assertEquals('abcd', $e->getParameter());
         }
     }
 

--- a/tests/Dissect/Lexer/AbstractLexerTest.php
+++ b/tests/Dissect/Lexer/AbstractLexerTest.php
@@ -60,7 +60,7 @@ class AbstractLexerTest extends PHPUnit_Framework_TestCase
             $this->fail('Expected a RecognitionException.');
         } catch (RecognitionException $e) {
             $this->assertEquals(1, $e->getSourceLine());
-            $this->assertEquals(0, $e->getPosition());
+            $this->assertEquals(3, $e->getPosition());
             $this->assertEquals('abcd', $e->getParameter());
         }
     }


### PR DESCRIPTION
Changed lexer and exception so that it is able to accept additional parameters:
- The token that caused the exception
- The line in the original string that contained the erroneous token
- The character position within that line where the token can be found
