### PR TITLE
Replace double declaration of parameter

### DIFF
--- a/tests/Dissect/Parser/LALR1/ArithGrammar.php
+++ b/tests/Dissect/Parser/LALR1/ArithGrammar.php
@@ -35,7 +35,7 @@ class ArithGrammar extends Grammar
             })
 
             ->is('(', 'Expr', ')')
-            ->call(function ($_, $e, $_) {
+            ->call(function ($_l, $e, $_r) {
                 return $e;
             })
 


### PR DESCRIPTION
In PHP7, a function parameter cannot be declared twice. Since I am currently updating a project to PHP7 that makes use of this lib, I came across this error.